### PR TITLE
example hack at solving the circular dependency issue

### DIFF
--- a/Emulator/cpu.js
+++ b/Emulator/cpu.js
@@ -1,7 +1,15 @@
-const { memory } = require('./memory');
 const { debug } = require('./debug tools');
 const { ppu } = require('./gpu');
 const { input } = require('./input');
+
+let memory = null;
+
+function initCpuMemory() {
+  if (!memory) {
+    memory = require('./memory').memory;
+    console.log(memory);
+  }
+}
 
 const cpu = {
 
@@ -3055,4 +3063,4 @@ const instructionMap = [
 ];
 
 
-module.exports = { cpu, wRAM };
+module.exports = { cpu, wRAM, initCpuMemory };

--- a/Emulator/emulator.js
+++ b/Emulator/emulator.js
@@ -1,7 +1,7 @@
 const { ppu, chrRom } = require('./gpu');
 const { memory } = require('./memory');
 let { prgRom } = require('./memory');
-const { cpu } = require('./cpu');
+const { cpu, initCpuMemory } = require('./cpu');
 const { mapperInit } = require('./mappers');
 
 const emulator = {
@@ -14,6 +14,7 @@ const emulator = {
   },
 
   runFrame() {
+    initCpuMemory();
     while (ppu.scanline === 0) {
       cpu.ex(memory.readByte(cpu.pc));
     }


### PR DESCRIPTION
-removed the global require for memory
-created a global variable for memory instead
-created an init function to call when memory is needed
-exporting init function
-using init function when running first frame